### PR TITLE
Non-root users access Secrets and ConfigMaps

### DIFF
--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -58,7 +58,7 @@ type (
 )
 
 func makeVolumeDir(dirPath string) error {
-	return os.MkdirAll(dirPath, os.ModeDir|0700)
+	return os.MkdirAll(dirPath, os.ModeDir|0750)
 }
 
 func MakeFetcher(logger *zap.Logger, sharedVolumePath string, sharedSecretPath string, sharedConfigPath string) (*Fetcher, error) {
@@ -106,7 +106,7 @@ func verifyChecksum(fileChecksum, checksum *fv1.Checksum) error {
 func writeSecretOrConfigMap(dataMap map[string][]byte, dirPath string) error {
 	for key, val := range dataMap {
 		writeFilePath := filepath.Join(dirPath, key)
-		err := ioutil.WriteFile(writeFilePath, val, 0600)
+		err := ioutil.WriteFile(writeFilePath, val, 0750)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to write file %s", writeFilePath)
 		}
@@ -347,7 +347,7 @@ func (fetcher *Fetcher) FetchSecretsAndCfgMaps(secrets []fv1.SecretReference, cf
 
 			secretPath := filepath.Join(secret.Namespace, secret.Name)
 			secretDir := filepath.Join(fetcher.sharedSecretPath, secretPath)
-			err = os.MkdirAll(secretDir, os.ModeDir|0644)
+			err = os.MkdirAll(secretDir, os.ModeDir|0750)
 			if err != nil {
 				e := "failed to create directory for secret"
 				fetcher.logger.Error(e,
@@ -391,7 +391,7 @@ func (fetcher *Fetcher) FetchSecretsAndCfgMaps(secrets []fv1.SecretReference, cf
 
 			configPath := filepath.Join(config.Namespace, config.Name)
 			configDir := filepath.Join(fetcher.sharedConfigPath, configPath)
-			err = os.MkdirAll(configDir, os.ModeDir|0644)
+			err = os.MkdirAll(configDir, os.ModeDir|0750)
 			if err != nil {
 				e := "failed to create directory for configmap"
 				fetcher.logger.Error(e,


### PR DESCRIPTION
When using custom environments with a non-root user, secrets and configmaps are inaccessible even if `fsGroup` is configured since the files are only accessible by the owner. Adding group read and execute allows `fsGroup` configuration to allow non-root users to access secrets and configmaps.

Additionally, it is not recommended to run privileged containers but it is sometimes unavoidable. Accessing function secrets and configmaps should not require root access.

Say your Dockerfile has this user
```Dockerfile
ENV USER=fission \
    UID=1000 \
    GID=1000

RUN addgroup --gid "$GID" "$USER" \
    && adduser \
    --disabled-password \
    --gecos "" \
    --home "/" \
    --ingroup "$USER" \
    --no-create-home \
    --uid "$UID" \
    "$USER"

USER 1000

ENTRYPOINT ["python3"]
CMD ["server.py"]

```

Then your Fission environment would be

```yaml
apiVersion: fission.io/v1
kind: Environment
metadata:
  name: fission-secret
  namespace: default
spec:
  builder:
    command: build
    image: fission/python-builder
  imagepullsecret: your-pull-secret
  keeparchive: false
  poolsize: 3
  resources: {}
  runtime:
    podspec:
      securityContext:
        fsGroup: 1000
    image: your-custom-image/name:1.0
  version: 2

```